### PR TITLE
Add dynamic alt text prompt with image type

### DIFF
--- a/lang/en/atto_image.php
+++ b/lang/en/atto_image.php
@@ -76,17 +76,14 @@ $string['generatealt'] = 'Generate Alt Text';
 $string['languages'] = 'Available Languages';
 $string['languages_desc'] = 'Enter available languages and their prompts in JSON format. Example: {"en":"Generate a concise alternative description for the image in English.","es":"Genera una descripción alternativa concisa para la imagen en español."}';
 $string['select_language'] = 'Select language';
-<<<<<<< codex/adicionar-campos-ao-settings.php-e-traduções
 $string['google_apikey'] = 'Google API Key';
 $string['google_apikey_desc'] = 'Enter your Google Vision API key';
 $string['google_apiurl'] = 'Google API URL';
 $string['google_apiurl_desc'] = 'Enter the Google Vision API URL';
 $string['categories'] = 'Default Categories';
 $string['categories_desc'] = 'Enter default image categories in JSON format. Example: {"photo":"Photo","screenshot":"Screenshot"}';
-=======
 $string['googleapikey'] = 'Google AI API Key';
 $string['googleapikey_desc'] = 'Enter your Google AI Studio API key';
 $string['googleapiurl'] = 'Google AI API URL';
 $string['googleapiurl_desc'] = 'Enter the Google AI Studio API URL (default: https://generativelanguage.googleapis.com/v1beta/models/gemini-pro-vision:generateContent)';
 $string['category'] = 'Category';
->>>>>>> master

--- a/lib.php
+++ b/lib.php
@@ -79,7 +79,7 @@ function atto_image_params_for_js($elementid, $options, $fpoptions) {
 
     $formattedLanguages = [];
     foreach ($languages as $code => $prompt) {
-        $formattedLanguages[] = ['code' => $code, 'name' => strtoupper($code) . ' - ' . substr($prompt, 0, 30) . '...'];
+        $formattedLanguages[] = ['code' => $code, 'name' => strtoupper($code)];
     }
 
     $params = array(

--- a/settings.php
+++ b/settings.php
@@ -107,7 +107,11 @@ if ($ADMIN->fulltree) {
     ));
 
     // Languages setting
-    $default_languages = json_encode(['en' => 'Generate a concise alternative description for the image in English.']);
+    $default_languages = json_encode([
+        'en' => 'English',
+        'pt-br' => 'Português',
+        'es' => 'Español'
+    ]);
     $settings->add(new admin_setting_configtextarea('atto_image/languages',
         get_string('languages', 'atto_image'),
         get_string('languages_desc', 'atto_image'),

--- a/yui/build/moodle-atto_image-button/moodle-atto_image-button-debug.js
+++ b/yui/build/moodle-atto_image-button/moodle-atto_image-button-debug.js
@@ -94,14 +94,14 @@ Y.namespace('M.atto_image').AltGenerator = {
      * @param {String} language The selected language code
      * @return {Promise} A promise that resolves with the generated alt text
      */
-    generateAltText: function(imageUrl, language, category) {
+    generateAltText: function(imageUrl, language, tipoimagem) {
         return new Promise(function(resolve, reject) {
             Y.io(M.cfg.wwwroot + '/lib/editor/atto/plugins/image/generate_alt.php', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded'
                 },
-                data: 'sesskey=' + M.cfg.sesskey + '&imageurl=' + encodeURIComponent(imageUrl) + '&language=' + encodeURIComponent(language) + '&category=' + encodeURIComponent(category),
+                data: 'sesskey=' + M.cfg.sesskey + '&imageurl=' + encodeURIComponent(imageUrl) + '&language=' + encodeURIComponent(language) + '&tipoimagem=' + encodeURIComponent(tipoimagem),
                 on: {
                     success: function(id, response) {
                         try {
@@ -276,12 +276,15 @@ var CSS = {
                         '<option value="{{code}}">{{name}}</option>' +
                     '{{/each}}' +
                 '</select>' +
-                '<label for="{{elementid}}_{{CSS.CATEGORYSELECTOR}}">Category</label>' +
-                '<select class="form-control {{CSS.CATEGORYSELECTOR}}" id="{{elementid}}_{{CSS.CATEGORYSELECTOR}}">' +
-                    '<option value="general">General</option>' +
-                    '<option value="nature">Nature</option>' +
-                    '<option value="technology">Technology</option>' +
-                '</select>' +
+                '<label>Tipo da imagem</label>' +
+                '<div class="{{CSS.CATEGORYSELECTOR}}">' +
+                    '<div class="form-check"><input class="form-check-input" type="radio" name="tipoimagem" value="foto" checked> Foto</div>' +
+                    '<div class="form-check"><input class="form-check-input" type="radio" name="tipoimagem" value="pintura"> Pintura/Ilustração</div>' +
+                    '<div class="form-check"><input class="form-check-input" type="radio" name="tipoimagem" value="print de conversa"> Print de conversa</div>' +
+                    '<div class="form-check"><input class="form-check-input" type="radio" name="tipoimagem" value="equação"> Equação</div>' +
+                    '<div class="form-check"><input class="form-check-input" type="radio" name="tipoimagem" value="gráfico"> Gráfico/Tabela/Diagrama</div>' +
+                    '<div class="form-check"><input class="form-check-input" type="radio" name="tipoimagem" value="outros"> Outros</div>' +
+                '</div>' +
             '</div>' +
             '<div class="mb-1">' +
                 '<button class="btn btn-secondary {{CSS.GENERATEALT}}" type="button">{{get_string "generatealt" component}} ({{currentLanguage}})</button>' +
@@ -903,17 +906,21 @@ Y.namespace('M.atto_image').Button = Y.Base.create('button', Y.M.editor_atto.Edi
         var altField = this._form.one('.' + CSS.INPUTALT);
         var urlField = this._form.one('.' + CSS.INPUTURL);
         var languageSelect = this._form.one('.' + CSS.LANGUAGESELECTOR);
-        var categorySelect = this._form.one('.' + CSS.CATEGORYSELECTOR);
+        var tipoSelect = this._form.one('.' + CSS.CATEGORYSELECTOR);
         var url = urlField.get('value');
         var language = languageSelect.get('value');
-        var category = categorySelect ? categorySelect.get('value') : '';
+        var tipoimagem = '';
+        if (tipoSelect) {
+            var checked = tipoSelect.one('input[type=radio]:checked');
+            tipoimagem = checked ? checked.get('value') : '';
+        }
     
         if (url) {
             // Show a loading indicator
             altField.set('value', 'Generating alt text...');
             this._handleKeyup();  // Update character count
     
-            Y.M.atto_image.AltGenerator.generateAltText(url, language, category).then(function(altText) {
+            Y.M.atto_image.AltGenerator.generateAltText(url, language, tipoimagem).then(function(altText) {
                 altField.set('value', altText);
                 this._handleKeyup();  // Update character count
             }.bind(this)).catch(function(error) {

--- a/yui/build/moodle-atto_image-button/moodle-atto_image-button.js
+++ b/yui/build/moodle-atto_image-button/moodle-atto_image-button.js
@@ -94,14 +94,14 @@ Y.namespace('M.atto_image').AltGenerator = {
      * @param {String} language The selected language code
      * @return {Promise} A promise that resolves with the generated alt text
      */
-    generateAltText: function(imageUrl, language, category) {
+    generateAltText: function(imageUrl, language, tipoimagem) {
         return new Promise(function(resolve, reject) {
             Y.io(M.cfg.wwwroot + '/lib/editor/atto/plugins/image/generate_alt.php', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded'
                 },
-                data: 'sesskey=' + M.cfg.sesskey + '&imageurl=' + encodeURIComponent(imageUrl) + '&language=' + encodeURIComponent(language) + '&category=' + encodeURIComponent(category),
+                data: 'sesskey=' + M.cfg.sesskey + '&imageurl=' + encodeURIComponent(imageUrl) + '&language=' + encodeURIComponent(language) + '&tipoimagem=' + encodeURIComponent(tipoimagem),
                 on: {
                     success: function(id, response) {
                         try {
@@ -276,12 +276,15 @@ var CSS = {
                         '<option value="{{code}}">{{name}}</option>' +
                     '{{/each}}' +
                 '</select>' +
-                '<label for="{{elementid}}_{{CSS.CATEGORYSELECTOR}}">Category</label>' +
-                '<select class="form-control {{CSS.CATEGORYSELECTOR}}" id="{{elementid}}_{{CSS.CATEGORYSELECTOR}}">' +
-                    '<option value="general">General</option>' +
-                    '<option value="nature">Nature</option>' +
-                    '<option value="technology">Technology</option>' +
-                '</select>' +
+                '<label>Tipo da imagem</label>' +
+                '<div class="{{CSS.CATEGORYSELECTOR}}">' +
+                    '<div class="form-check"><input class="form-check-input" type="radio" name="tipoimagem" value="foto" checked> Foto</div>' +
+                    '<div class="form-check"><input class="form-check-input" type="radio" name="tipoimagem" value="pintura"> Pintura/Ilustração</div>' +
+                    '<div class="form-check"><input class="form-check-input" type="radio" name="tipoimagem" value="print de conversa"> Print de conversa</div>' +
+                    '<div class="form-check"><input class="form-check-input" type="radio" name="tipoimagem" value="equação"> Equação</div>' +
+                    '<div class="form-check"><input class="form-check-input" type="radio" name="tipoimagem" value="gráfico"> Gráfico/Tabela/Diagrama</div>' +
+                    '<div class="form-check"><input class="form-check-input" type="radio" name="tipoimagem" value="outros"> Outros</div>' +
+                '</div>' +
             '</div>' +
             '<div class="mb-1">' +
                 '<button class="btn btn-secondary {{CSS.GENERATEALT}}" type="button">{{get_string "generatealt" component}} ({{currentLanguage}})</button>' +
@@ -903,17 +906,21 @@ Y.namespace('M.atto_image').Button = Y.Base.create('button', Y.M.editor_atto.Edi
         var altField = this._form.one('.' + CSS.INPUTALT);
         var urlField = this._form.one('.' + CSS.INPUTURL);
         var languageSelect = this._form.one('.' + CSS.LANGUAGESELECTOR);
-        var categorySelect = this._form.one('.' + CSS.CATEGORYSELECTOR);
+        var tipoSelect = this._form.one('.' + CSS.CATEGORYSELECTOR);
         var url = urlField.get('value');
         var language = languageSelect.get('value');
-        var category = categorySelect ? categorySelect.get('value') : '';
+        var tipoimagem = '';
+        if (tipoSelect) {
+            var checked = tipoSelect.one('input[type=radio]:checked');
+            tipoimagem = checked ? checked.get('value') : '';
+        }
     
         if (url) {
             // Show a loading indicator
             altField.set('value', 'Generating alt text...');
             this._handleKeyup();  // Update character count
     
-            Y.M.atto_image.AltGenerator.generateAltText(url, language, category).then(function(altText) {
+            Y.M.atto_image.AltGenerator.generateAltText(url, language, tipoimagem).then(function(altText) {
                 altField.set('value', altText);
                 this._handleKeyup();  // Update character count
             }.bind(this)).catch(function(error) {

--- a/yui/src/button/js/altgenerator.js
+++ b/yui/src/button/js/altgenerator.js
@@ -31,14 +31,14 @@ Y.namespace('M.atto_image').AltGenerator = {
      * @param {String} language The selected language code
      * @return {Promise} A promise that resolves with the generated alt text
      */
-    generateAltText: function(imageUrl, language, category) {
+    generateAltText: function(imageUrl, language, tipoimagem) {
         return new Promise(function(resolve, reject) {
             Y.io(M.cfg.wwwroot + '/lib/editor/atto/plugins/image/generate_alt.php', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded'
                 },
-                data: 'sesskey=' + M.cfg.sesskey + '&imageurl=' + encodeURIComponent(imageUrl) + '&language=' + encodeURIComponent(language) + '&category=' + encodeURIComponent(category),
+                data: 'sesskey=' + M.cfg.sesskey + '&imageurl=' + encodeURIComponent(imageUrl) + '&language=' + encodeURIComponent(language) + '&tipoimagem=' + encodeURIComponent(tipoimagem),
                 on: {
                     success: function(id, response) {
                         try {

--- a/yui/src/button/js/button.js
+++ b/yui/src/button/js/button.js
@@ -152,12 +152,15 @@ var CSS = {
                         '<option value="{{code}}">{{name}}</option>' +
                     '{{/each}}' +
                 '</select>' +
-                '<label for="{{elementid}}_{{CSS.CATEGORYSELECTOR}}">Category</label>' +
-                '<select class="form-control {{CSS.CATEGORYSELECTOR}}" id="{{elementid}}_{{CSS.CATEGORYSELECTOR}}">' +
-                    '<option value="general">General</option>' +
-                    '<option value="nature">Nature</option>' +
-                    '<option value="technology">Technology</option>' +
-                '</select>' +
+                '<label>Tipo da imagem</label>' +
+                '<div class="{{CSS.CATEGORYSELECTOR}}">' +
+                    '<div class="form-check"><input class="form-check-input" type="radio" name="tipoimagem" value="foto" checked> Foto</div>' +
+                    '<div class="form-check"><input class="form-check-input" type="radio" name="tipoimagem" value="pintura"> Pintura/Ilustração</div>' +
+                    '<div class="form-check"><input class="form-check-input" type="radio" name="tipoimagem" value="print de conversa"> Print de conversa</div>' +
+                    '<div class="form-check"><input class="form-check-input" type="radio" name="tipoimagem" value="equação"> Equação</div>' +
+                    '<div class="form-check"><input class="form-check-input" type="radio" name="tipoimagem" value="gráfico"> Gráfico/Tabela/Diagrama</div>' +
+                    '<div class="form-check"><input class="form-check-input" type="radio" name="tipoimagem" value="outros"> Outros</div>' +
+                '</div>' +
             '</div>' +
             '<div class="mb-1">' +
                 '<button class="btn btn-secondary {{CSS.GENERATEALT}}" type="button">{{get_string "generatealt" component}} ({{currentLanguage}})</button>' +
@@ -779,17 +782,21 @@ Y.namespace('M.atto_image').Button = Y.Base.create('button', Y.M.editor_atto.Edi
         var altField = this._form.one('.' + CSS.INPUTALT);
         var urlField = this._form.one('.' + CSS.INPUTURL);
         var languageSelect = this._form.one('.' + CSS.LANGUAGESELECTOR);
-        var categorySelect = this._form.one('.' + CSS.CATEGORYSELECTOR);
+        var tipoSelect = this._form.one('.' + CSS.CATEGORYSELECTOR);
         var url = urlField.get('value');
         var language = languageSelect.get('value');
-        var category = categorySelect ? categorySelect.get('value') : '';
+        var tipoimagem = '';
+        if (tipoSelect) {
+            var checked = tipoSelect.one('input[type=radio]:checked');
+            tipoimagem = checked ? checked.get('value') : '';
+        }
     
         if (url) {
             // Show a loading indicator
             altField.set('value', 'Generating alt text...');
             this._handleKeyup();  // Update character count
     
-            Y.M.atto_image.AltGenerator.generateAltText(url, language, category).then(function(altText) {
+            Y.M.atto_image.AltGenerator.generateAltText(url, language, tipoimagem).then(function(altText) {
                 altField.set('value', altText);
                 this._handleKeyup();  // Update character count
             }.bind(this)).catch(function(error) {


### PR DESCRIPTION
## Summary
- update language list and UI for image type radio buttons
- send `tipoimagem` to alt text generator
- add Portuguese prompt template with language/type variables
- clean up language string file

## Testing
- `php -l generate_alt.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cbcd548008322898d5bb300198d1e